### PR TITLE
Update OPA version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.13.7-stretch
 
-ENV OPA_VERSION=v0.17.1
+ENV OPA_VERSION=v0.18.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
Required to use [`object` functions implemented in 0.17.2](https://github.com/open-policy-agent/opa/releases/tag/v0.17.2) 0.18.0 doesn't have backward incompatible changes. (0.19.0 has, which is why I choose 0.18.0 as the latest version behind 0.19.0)