### PR TITLE
deprecate set-output command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ main() {
   run_opa "$@" 2>&1 | tee -a result
   result="$(cat result)"
   # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
-  echo "::set-output name=result::${result//$'\n'/'%0A'}"
+  echo "result=${result//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
 }
 
 set -o pipefail


### PR DESCRIPTION
**WHAT**
Update the output command to "`echo 'key=value' >> $GITHUB_OUTPUT`" because 'set-output' command has been deprecated

**WHY**
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
